### PR TITLE
fix: calculate ceil of STREAM_HASH_COUNT & drop lock before notifying others

### DIFF
--- a/gpu-cpu-test/src/lib.rs
+++ b/gpu-cpu-test/src/lib.rs
@@ -14,7 +14,7 @@ mod tests {
     pub const TEST_CONFIG: Config = Config {
         k: 2,
         num_nodes_window: 512, // Must be 2^(3*x) for 8-ary merkle trees
-        degree_expander: 96,
+        degree_expander: 56,
         degree_butterfly: 4,
         num_expander_layers: 4,
         num_butterfly_layers: 3,

--- a/src/cl/expander.cl
+++ b/src/cl/expander.cl
@@ -1,5 +1,4 @@
 #define BYTE_SIZE (BIT_SIZE / 8)
-#define STREAM_HASH_COUNT (DEGREE_EXPANDER * BIT_SIZE / sha256_BITS)
 
 // We are going to generate and store the entire bit-stream per node
 // before running the expander algorithm. Is this a good idea?

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -76,6 +76,7 @@ impl SealerPool {
                                 }
                             }
                             *busy = false;
+                            drop(busy);
                             cond.notify_all(); // Notify that one GPU is not busy anymore
                             info!("Device[{}]: Sealing finished, waiting for inputs...", i);
                         }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -9,13 +9,17 @@ static EXPANDER_SRC: &str = include_str!("cl/expander.cl");
 static BUTTERFLY_SRC: &str = include_str!("cl/butterfly.cl");
 static COMBINE_SRC: &str = include_str!("cl/combine.cl");
 
+static SHA256_BITS: usize = 256;
+
 fn config(conf: Config) -> String {
     assert!(conf.num_nodes_window > conf.k as usize);
     assert!(conf.num_nodes_window.count_ones() == 1);
     assert!(conf.k.count_ones() == 1);
-    let bit_size = (conf.num_nodes_window as f64 / conf.k as f64).log2() as u32;
+    let bit_size = (conf.num_nodes_window as f64 / conf.k as f64).log2() as usize;
     assert!(bit_size % 8 == 0);
     assert!(conf.degree_butterfly.count_ones() == 1);
+    let stream_hash_count =
+        ((conf.degree_expander * bit_size) as f64 / SHA256_BITS as f64).ceil() as usize;
 
     format!(
         "#define N ({})
@@ -26,7 +30,8 @@ fn config(conf: Config) -> String {
          #define LOG2_DEGREE_BUTTERFLY ({})
          #define NUM_EXPANDER_LAYERS ({})
          #define NUM_BUTTERFLY_LAYERS ({})
-         #define BIT_SIZE ({})\n",
+         #define BIT_SIZE ({})
+         #define STREAM_HASH_COUNT ({})\n",
         conf.num_nodes_window,
         conf.k,
         (conf.k as f64).log2() as u32,
@@ -36,6 +41,7 @@ fn config(conf: Config) -> String {
         conf.num_expander_layers,
         conf.num_butterfly_layers,
         bit_size,
+        stream_hash_count,
     )
 }
 


### PR DESCRIPTION
Expander layer was returning wrong results when `BIT_SIZE * DEGREE_EXPANDER` was not divisible by 256 (Number of SHA256 bits) 